### PR TITLE
Replace regexp to work with unicode words.

### DIFF
--- a/src/active-document.js
+++ b/src/active-document.js
@@ -8,7 +8,7 @@ class ActiveDocument {
   static getWordCount() {
     const editor = vscode.window.activeTextEditor;
     const text = editor.document.getText();
-    let matches = text.match(/\w+/g);
+    let matches = text.match(/[\p{L}\p{N}]+/igu);
 
     if (matches === null) {
       return 0;


### PR DESCRIPTION
Thanks to @krimsit, i've found the regex, that would work with unicode words.
https://repl.it/@dadyarri/StormyInsidiousSweepsoftware#index.js
(Fixes #1)

cc @robole, would you check, please?