### PR TITLE
Fix text sample's length affected by active line endings on machine

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/suite/test-*.md eol=lf


### PR DESCRIPTION
Fix: the test fails on a system with CRLF line endings, since the test files received by the git have a different length.

```
rejected promise not handled within 1 second: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
244 !== 241
1) getCharacterCount for english text

...

rejected promise not handled within 1 second: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
168 !== 167
2) getCharacterCount for russian text
```