### PR TITLE
Add counter "Author's Sheets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,17 @@ The extension is only loaded when a markdown file is open. To be more specific, 
 
 ## Settings
 
-| Name                                               | Type    | Default | Description                                            |
-| -------------------------------------------------- | ------- | ------- | ------------------------------------------------------ |
-| Marky Markdown: Stats Show Reading Time | Boolean | true    | Show "Reading Time" on the status bar.       |
-| Marky Markdown: Stats Show Words        | Boolean | false   | Show "Words" counter on the status bar.      |
-| Marky Markdown: Stats Show Lines        | Boolean | false   | Show "Lines" counter on the status bar.      |
-| Marky Markdown: Stats Show Characters   | Boolean | false   | Show "Characters" counter on the status bar. |
-| Marky Markdown: Stats Item Separator  | String  | 2 spaces | Separator between items on status bar.                 |
-| Marky Markdown: Stats Words Per Minute | Integer | 250    | Set the words per minute that is used to calculate "Reading Time".      |
-| Marky Markdown: Stats Alignment | String (enum) | "Left"   | Set the position on the status bar. Values are : "Left" and "Right". *Requires restart of VS Code* to show new position.     |
+| Name                                                | Type          | Default  | Description                                                                                                              |
+| --------------------------------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Marky Markdown: Stats Show Reading Time             | Boolean       | true     | Show "Reading Time" on the status bar.                                                                                   |
+| Marky Markdown: Stats Show Words                    | Boolean       | false    | Show "Words" counter on the status bar.                                                                                  |
+| Marky Markdown: Stats Show Lines                    | Boolean       | false    | Show "Lines" counter on the status bar.                                                                                  |
+| Marky Markdown: Stats Show Characters               | Boolean       | false    | Show "Characters" counter on the status bar.                                                                             |
+| Marky Markdown: Stats Show Author's Sheets          | Boolean       | false    | Show "Author's Sheets" counter on the status bar.                                                                        |
+| Marky Markdown: Stats Item Separator                | String        | 2 spaces | Separator between items on status bar.                                                                                   |
+| Marky Markdown: Stats Words Per Minute              | Integer       | 250      | Set the words per minute that is used to calculate "Reading Time".                                                       |
+| Marky Markdown: Stats Characters per Author's Sheet | Integer       | 40000    | Set the characters per author's sheet that is used to calculate "Author's Sheet".                                        |
+| Marky Markdown: Stats Alignment                     | String (enum) | "Left"   | Set the position on the status bar. Values are : "Left" and "Right". *Requires restart of VS Code* to show new position. |
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "markyMarkdown.statsCharactersPerAuthorsSheet": {
           "type": "integer",
           "default": 40000,
-          "description": "Set the number of characters per one author's page."
+          "description": "Set the number of characters per one author's sheet."
         },
         "markyMarkdown.statsShowAuthorsSheets": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,16 @@
           "default": false,
           "description": "Show \"Characters\" counter on the status bar."
         },
+        "markyMarkdown.statsCharactersPerAuthorsSheet": {
+          "type": "integer",
+          "default": 40000,
+          "description": "Set the number of characters per one author's page."
+        },
+        "markyMarkdown.statsShowAuthorsSheets": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show \"Author's Sheets\" counter on the status bar."
+        },
         "markyMarkdown.statsItemSeparator": {
           "type": "string",
           "default": "  ",

--- a/src/activeDocument.js
+++ b/src/activeDocument.js
@@ -55,6 +55,23 @@ class ActiveDocument {
     return 0;
   }
 
+	/**
+	 * Get the number of author's sheets ().
+	 *
+	 */
+	static getAuthorsSheets() {
+		const editor = vscode.window.activeTextEditor;
+
+		if (editor !== undefined && editor.document !== undefined) {
+			const text = editor.document.getText();
+			const charactersPerAuthorsSheet = Configuration.getCharactersPerAuthorsSheet();
+
+			return (Math.floor(text.length * 100 / charactersPerAuthorsSheet) / 100).toFixed(2);
+		}
+
+		return 0;
+	}
+
   /**
    * Get the number of lines.
    *

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -10,6 +10,8 @@ const showReadingTimeName = "statsShowReadingTime";
 const showWordsName = "statsShowWords";
 const showLinesName = "statsShowLines";
 const showCharactersName = "statsShowCharacters";
+const charactersPerAuthorsSheet = "statsCharactersPerAuthorsSheet";
+const showAuthorsSheets = "statsShowAuthorsSheets";
 const itemSeparatorName = "statsItemSeparator";
 const alignmentName = "statsAlignment";
 
@@ -84,6 +86,28 @@ class Configuration {
     return show;
   }
 
+  static getCharactersPerAuthorsSheet() {
+    let number = 40000;
+
+    if (vscode.workspace) {
+      const config = vscode.workspace.getConfiguration(prefix);
+      number = parseInt(config.get(charactersPerAuthorsSheet));
+    }
+
+    return number;
+  }
+
+  static getShowAuthorsSheets() {
+    let show = false;
+
+    if (vscode.workspace) {
+      const config = vscode.workspace.getConfiguration(prefix);
+      show = config.get(showAuthorsSheets);
+    }
+
+    return show;
+  }
+
   static getItemSeparator() {
     let separator = "  ";
 
@@ -127,6 +151,20 @@ class Configuration {
     if (vscode.workspace) {
       const config = vscode.workspace.getConfiguration(prefix);
       await config.update(showCharactersName, newValue, scope);
+    }
+  }
+
+  static async updateCharactersPerAuthorsSheet(newValue) {
+    if (vscode.workspace) {
+      const config = vscode.workspace.getConfiguration(prefix);
+      await config.update(charactersPerAuthorsSheet, newValue, scope);
+    }
+  }
+
+  static async updateShowAuthorsSheets(newValue) {
+    if (vscode.workspace) {
+      const config = vscode.workspace.getConfiguration(prefix);
+      await config.update(showAuthorsSheets, newValue, scope);
     }
   }
 

--- a/src/statisticPicker.js
+++ b/src/statisticPicker.js
@@ -9,6 +9,7 @@ const labels = {
   WORDS: "Words",
   LINES: "Lines",
   CHARACTERS: "Characters",
+  AUTHORSSHEETS: "Author's Sheets",
 };
 
 class StatisticPicker {
@@ -49,6 +50,10 @@ class StatisticPicker {
     this.quickPickItems[3] = {
       name: labels.CHARACTERS,
       label: `${labels.CHARACTERS}: ${ActiveDocument.getCharacterCount()}`,
+    };
+    this.quickPickItems[4] = {
+      name: labels.AUTHORSSHEETS,
+      label: `${labels.AUTHORSSHEETS}: ${ActiveDocument.getAuthorsSheets()}`,
     };
 
     let filteredItems = this.quickPickItems.filter(
@@ -138,6 +143,10 @@ class StatisticPicker {
     await Configuration.updateShowCharacters(
       this.selectedItems.indexOf(labels.CHARACTERS) >= 0
     );
+
+    await Configuration.updateShowAuthorsSheets(
+      this.selectedItems.indexOf(labels.AUTHORSSHEETS) >= 0
+    );
   }
 
   /**
@@ -163,9 +172,15 @@ class StatisticPicker {
       selectedItems.push(labels.CHARACTERS);
     }
 
+    if (Configuration.getShowAuthorsSheets() === true) {
+      selectedItems.push(labels.AUTHORSSHEETS);
+    }
+
     this.selectedItems = selectedItems;
 
     this.itemSeparator = Configuration.getItemSeparator();
+
+    this.charactersPerAuthorsSheet = Configuration.getCharactersPerAuthorsSheet();
 
     let alignment = Configuration.getAlignment();
 
@@ -190,6 +205,14 @@ class StatisticPicker {
    */
   async setItemSeparator(newValue) {
     this.itemSeparator = newValue;
+  }
+
+  /**
+   * Set the number of characters per author's sheet. Only used for testing in this context.
+   * @param {string} newValue - The number of characters per author's sheet.
+   */
+  async setCharactersPerAuthorsSheet(newValue) {
+    this.charactersPerAuthorsSheet = newValue;
   }
 
   /**

--- a/test/suite/statisticPicker.test.js
+++ b/test/suite/statisticPicker.test.js
@@ -49,4 +49,16 @@ suite("Statistic Display", () => {
 
     assert.strictEqual(text, "Reading Time: 1 mins,Words: 31");
   });
+
+  test("Should be able to update the number of characters per author's sheet", async () => {
+    var s = extension.exports.getStatisticPicker();
+    s.setSelectedItems(["Author's Sheets"]);
+    await s.setCharactersPerAuthorsSheet(10);
+    s.update();
+    let text = s.getText();
+
+    await s.setCharactersPerAuthorsSheet(40000); //reset setting
+
+    assert.strictEqual(text, "Author's Sheets: 24.10");
+  });
 });


### PR DESCRIPTION
Implements **Author's Sheets** counter. 
> The **author's sheet**  is a unit used in Russia and post-Soviet countries to measure the volume of a literary work created by the author or processed by a translator, editor or proofreader. - [Wikipedia](https://ru.wikipedia.org/wiki/%D0%90%D0%B2%D1%82%D0%BE%D1%80%D1%81%D0%BA%D0%B8%D0%B9_%D0%BB%D0%B8%D1%81%D1%82)